### PR TITLE
Performance improvement for img_info

### DIFF
--- a/is_alpha_constant.py
+++ b/is_alpha_constant.py
@@ -1,7 +1,7 @@
 """
-Tells if alpha(pixel) == const over al imahe pixels
+Tells if alpha(pixel) == const over all image pixels
 
-Sintax:
+Syntax:
     img.py filename
 """
 import sys
@@ -16,9 +16,8 @@ def img_info(img_path):
         # has a constant alpha value?
         im_a = im.getchannel('A')
         data = np.asarray(im_a)
-        a0 = data[0][0] 
-        uf = np.vectorize(lambda a: a==a0)
-        is_const = np.all(uf(data)) 
+        a0 = data[0][0]
+        is_const = np.all(data == a0)
         if is_const:
             print("image has constant alpha value ==", a0)
         else:


### PR DESCRIPTION
Better use of numpy vectorization

```
In [21]: import numpy as np

In [22]: a = np.full((640, 480), 150)

In [23]: %timeit np.all(np.vectorize(lambda x: x == a[0][0])(a))
102 ms ± 1.02 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [24]: %timeit np.all(a == a[0][0])
90.6 µs ± 499 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
So this is a speedup by several orders of magnitude (100X). I'm sure this is not necessary a bottleneck, but I thought you might like the change.